### PR TITLE
Fix PDF output path handling

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -158,10 +158,11 @@ Contact:
 		barImgtoPdf := progressbar.Default(int64(totalPages), "Generating PDF...")
 		pdfPath := fmt.Sprintf("%s.pdf", sanitizeFilename(book.Title))
 		for i := startPage; i <= (startPage-1)+totalPages; i++ {
-
 			filename := fmt.Sprintf("%s/%d_%d.jpeg", screenshotDir, book.Id, i)
-			// Generate PDF and append
-			pdfcpu.ImportImagesFile([]string{filename}, fmt.Sprintf("%s.pdf", book.Title), nil, model.NewDefaultConfiguration())
+			// Generate PDF and append to the sanitized output file
+			if err := pdfcpu.ImportImagesFile([]string{filename}, pdfPath, nil, model.NewDefaultConfiguration()); err != nil {
+				log.Fatalf("could not import image %s: %v", filename, err)
+			}
 			barImgtoPdf.Add(1)
 		}
 

--- a/pkg/edubase/book.go
+++ b/pkg/edubase/book.go
@@ -79,7 +79,8 @@ func (b *BookProvider) Screenshot(filename string) error {
 	}
 
 	// check if filename has the correct extension
-	if !regexp.MustCompile(`.*\.jpe?g`).MatchString(filename) {
+	// ensure filename ends with .jpg or .jpeg (case-insensitive)
+	if !regexp.MustCompile(`(?i)\.jpe?g$`).MatchString(filename) {
 		return fmt.Errorf("filename has the wrong extension")
 	}
 


### PR DESCRIPTION
## Summary
- ensure images are appended to sanitized PDF path
- validate screenshot filenames end with `.jpg`/`.jpeg`

## Testing
- `go test ./...` *(fails: could not install driver / browsers)*

------
https://chatgpt.com/codex/tasks/task_e_684bee82bc188329b2ab3263f7d391fa