### PR TITLE
fix: wait for all library items to load before scraping

### DIFF
--- a/pkg/edubase/library.go
+++ b/pkg/edubase/library.go
@@ -42,11 +42,16 @@ func (l *LibraryProvider) GetBooks() ([]Book, error) {
 		return []Book{}, fmt.Errorf("timed out waiting for library items to appear: %w", err)
 	}
 
-	// wait for network to settle so all books (including paid) finish loading
-	_ = l.page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+	// Wait for network to settle so all books (including paid) finish loading.
+	// NetworkIdle may not resolve if the app uses persistent connections (e.g.
+	// WebSockets, long-polling). A timeout here is acceptable because the
+	// stabilization delay below still gives remaining items time to render.
+	if err := l.page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
 		State:   playwright.LoadStateNetworkidle,
 		Timeout: playwright.Float(float64(l.timeout.Milliseconds())),
-	})
+	}); err != nil {
+		// non-fatal: proceed with whatever has loaded
+	}
 
 	// allow final DOM mutations after last API response
 	time.Sleep(l.stabilizationDelay)
@@ -55,6 +60,9 @@ func (l *LibraryProvider) GetBooks() ([]Book, error) {
 	if err != nil {
 		return []Book{}, err
 	}
+
+	// Clear any previously fetched books to avoid duplicates on repeated calls.
+	l.Books = nil
 
 	for _, libraryItem := range libraryItems {
 		bookId, err := libraryItem.GetAttribute("data-last-available-version")

--- a/pkg/edubase/library.go
+++ b/pkg/edubase/library.go
@@ -1,6 +1,7 @@
 package edubase
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -8,18 +9,20 @@ import (
 )
 
 type LibraryProvider struct {
-	page         playwright.Page
-	baseURL      string
-	Books        []Book
-	initialDelay time.Duration
+	page               playwright.Page
+	baseURL            string
+	Books              []Book
+	timeout            time.Duration
+	stabilizationDelay time.Duration
 }
 
 func NewLibraryProvider(page playwright.Page) *LibraryProvider {
 	return &LibraryProvider{
-		page:         page,
-		baseURL:      "https://app.edubase.ch",
-		Books:        []Book{},
-		initialDelay: 500 * time.Millisecond,
+		page:               page,
+		baseURL:            "https://app.edubase.ch",
+		Books:              []Book{},
+		timeout:            15 * time.Second,
+		stabilizationDelay: 2 * time.Second,
 	}
 }
 
@@ -29,10 +32,26 @@ type Book struct {
 }
 
 func (l *LibraryProvider) GetBooks() ([]Book, error) {
-	// wait for the library page to load
-	time.Sleep(l.initialDelay)
+	// wait for at least one library item to be visible in the DOM
+	itemLocator := l.page.Locator("#libraryItems > li:not(:first-child)")
+	err := itemLocator.First().WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(float64(l.timeout.Milliseconds())),
+	})
+	if err != nil {
+		return []Book{}, fmt.Errorf("timed out waiting for library items to appear: %w", err)
+	}
 
-	libraryItems, err := l.page.Locator("#libraryItems > li:not(:first-child)").All()
+	// wait for network to settle so all books (including paid) finish loading
+	_ = l.page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+		State:   playwright.LoadStateNetworkidle,
+		Timeout: playwright.Float(float64(l.timeout.Milliseconds())),
+	})
+
+	// allow final DOM mutations after last API response
+	time.Sleep(l.stabilizationDelay)
+
+	libraryItems, err := itemLocator.All()
 	if err != nil {
 		return []Book{}, err
 	}


### PR DESCRIPTION
## Summary
  - Paid/purchased books were missing from the book selection list because the 500ms fixed delay was too short for async ownership API calls to complete
  - Replaced `time.Sleep(500ms)` with a three-phase wait: Playwright `WaitFor` (up to 15s), `NetworkIdle`, and a 2s stabilization delay
  - Only free books (Edubase Handbuch, Magazin, User Manual) appeared before this fix

  Closes #43

  ## Test plan
  - [ ] `go build ./...` passes
  - [ ] Run `edubase-to-pdf import` with an account that owns paid books
  - [ ] Verify paid books now appear in the selection list
  - [ ] Verify free-only accounts still work correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library loading: replaced fixed delay with visibility and network readiness checks, added configurable timeout and stabilization delay, and made network-wait non-fatal so loading proceeds gracefully.
  * Prevented duplicate entries by clearing previous results before repopulating.
  * Surface clearer load errors and return an empty list on visibility failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->