### PR TITLE
fix: select last span for total pages to handle updated pagination DOM

### DIFF
--- a/pkg/edubase/book.go
+++ b/pkg/edubase/book.go
@@ -41,7 +41,7 @@ func (b *BookProvider) Open(page int) error {
 func (b *BookProvider) GetTotalPages() (int, error) {
 	time.Sleep(b.initialDelay)
 
-	rawTotalPages, err := b.page.Locator("#pagination > div > span").First().InnerText()
+	rawTotalPages, err := b.page.Locator("#pagination > div > span").Last().InnerText()
 	if err != nil {
 		return 0, fmt.Errorf("could not get max page number: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Fixes #45 — `GetTotalPages()` aborts with `could not find max page number: /`.
- Edubase's pagination now renders as `"current / total"` with the first direct-child `<span>` under `#pagination > div` being the `/` separator, so `.First().InnerText()` returns `/` and the `[0-9]+` regex finds no digits.
- Switch the Playwright locator from `.First()` to `.Last()` so the total-pages span is read. Regex and `strconv.Atoi` logic stay the same.

The current-page locator used by `TestNextPage` (`#pagination > div > div > span`) targets a different, nested span and is unaffected — which also corroborates that the direct-child spans are `[separator, total]`.

## Test plan

- [ ] `go build ./...` (done locally, clean)
- [ ] `go vet ./...` (done locally, clean)
- [ ] With `EDUBASE_EMAIL` / `EDUBASE_PASSWORD` set, run `go test ./pkg/edubase/ -run 'TestGetTotalPages|TestNextPage' -v` — `TestGetTotalPages` should pass with `totalPages == 38` for book 58216.
- [ ] Reproduce the issue #45 scenario end-to-end with the CLI on a real book (e.g. `edubase-to-pdf import -e … -p … -m <id>`) and confirm the error no longer fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination value retrieval to read from the correct source, ensuring accurate total page count calculations when navigating books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->